### PR TITLE
Add RUNE_JSON boolean to ingest and projection annotations

### DIFF
--- a/rune-runtime/src/main/resources/model/annotations.rosetta
+++ b/rune-runtime/src/main/resources/model/annotations.rosetta
@@ -23,6 +23,7 @@ annotation deprecated: <"Marks a type, function or enum as deprecated and will b
 
 annotation ingest: <"Marks a function that performs ingestion operations with the in bound serialisation format">
 	JSON boolean (0..1)
+	RUNE_JSON boolean (0..1)
 	XML boolean (0..1)
 	CSV boolean (0..1)
 
@@ -30,6 +31,7 @@ annotation enrich: <"Marks a function that performs enrichment operations">
 	
 annotation projection: <"Marks a function that performs projection operations with the out bound serialisation format">
 	JSON boolean (0..1)
+	RUNE_JSON boolean (0..1)
 	XML boolean (0..1)
 	CSV boolean (0..1)
 	


### PR DESCRIPTION
Story-1522: Added RUNE_JSON boolean support for ingest and projection annotations.

## Type of change

- New feature (non-breaking change which adds functionality)
